### PR TITLE
Issue #33: promote governance marker to governed

### DIFF
--- a/.context-engineering/governance.yml
+++ b/.context-engineering/governance.yml
@@ -4,12 +4,12 @@ repository: "Josh-Phillips-LLC/mcp-auth-broker"
 governance:
   owner_system: "Context-Engineering"
   owner_repo: "Josh-Phillips-LLC/Context-Engineering"
-  state: "transition"
+  state: "governed"
   registry_ref: "00-os/governed-repos.yml"
   policy_ref: "governance.md#repository-governance-adoption-model-ownership-states"
 
 controls:
-  profile: "transition"
+  profile: "governed"
   required_reviews:
     - "Compliance Officer"
 
@@ -17,4 +17,4 @@ evidence:
   adoption_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/20"
   rollout_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/20"
 
-last_reviewed_utc: "2026-02-25T00:00:00Z"
+last_reviewed_utc: "2026-02-25T09:25:10Z"


### PR DESCRIPTION
## Summary
- update `.context-engineering/governance.yml` marker from `transition` to `governed`
- set `controls.profile` to `governed`
- refresh `last_reviewed_utc`

## Machine-Readable Metadata (Required)
Primary-Role: Systems Architect
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Not-Required

Refs: Josh-Phillips-LLC/Context-Engineering#33
